### PR TITLE
Install to chocolatey toolsdir

### DIFF
--- a/packages/f.lux/tools/chocolateyinstall.ps1
+++ b/packages/f.lux/tools/chocolateyinstall.ps1
@@ -1,18 +1,9 @@
-$ErrorActionPreference = 'Stop'
- 
-$packageName = 'f.lux'
-$url32       = 'http://stereopsis.com/flux/flux-setup.exe'
-$checksum32  = '99F6A5FCF8C6789FF4D69A98B6CB1AF9296A76F210C01A6C8A0716EF79134F2F'
- 
 $packageArgs = @{
-  packageName            = $packageName
-  fileType               = 'exe'
-  url                    = $url32
-  silentArgs             = '/S'
-  checksum               = $checksum32
+  packageName            = 'f.lux'
+  url                    = 'http://stereopsis.com/flux/flux-setup.exe'
+  checksum               = '99F6A5FCF8C6789FF4D69A98B6CB1AF9296A76F210C01A6C8A0716EF79134F2F'
   checksumType           = 'sha256'
-  validExitCodes         = @(0)
-  registryUninstallerKey = $packageName
+  UnzipLocation 	 = "$(Split-Path -parent $MyInvocation.MyCommand.Definition)"
 }
  
-Install-ChocolateyPackage @packageArgs
+Install-ChocolateyZipPackage @packageArgs


### PR DESCRIPTION
f.lux's native installer is broken and unconfigurable. Luckily, we don't need it. By simply using the chocolatey install zip function, we can cleanly install f.lux system wide.

F.lux User configuration is stored in HKCU, this will 'just work' without issue.

The Windows start menu can run binaries on PATH. No shortcuts are necessary, just press start and type 'flux'. We can, of course, create the shortcuts with chocolatey functions if that is desired.